### PR TITLE
释放服务器上面sftp-server进程

### DIFF
--- a/server/term/next_terminal.go
+++ b/server/term/next_terminal.go
@@ -80,6 +80,11 @@ func (ret *NextTerminal) Write(p []byte) (int, error) {
 }
 
 func (ret *NextTerminal) Close() error {
+	
+	if ret.SftpClient != nil {
+		return ret.SftpClient.Close()
+	}
+	
 	if ret.SshSession != nil {
 		return ret.SshSession.Close()
 	}


### PR DESCRIPTION
如果不关闭，会在服务器上面产生大量的 /usr/libexec/openssh/sftp-server 进程