### PR TITLE
🐞 fix: 修复无法正常关闭代理隧道

### DIFF
--- a/server/global/gateway/gateway.go
+++ b/server/global/gateway/gateway.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -92,7 +91,6 @@ func (g *Gateway) OpenSshTunnel(id, ip string, port int) (exposedIP string, expo
 		return "", 0, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
 	tunnel := &Tunnel{
 		ID:        id,
 		LocalHost: hostname,
@@ -101,8 +99,6 @@ func (g *Gateway) OpenSshTunnel(id, ip string, port int) (exposedIP string, expo
 		Gateway:    g,
 		RemoteHost: ip,
 		RemotePort: port,
-		ctx:        ctx,
-		cancel:     cancel,
 		listener:   listener,
 	}
 	g.Add <- tunnel

--- a/server/global/gateway/tunnel.go
+++ b/server/global/gateway/tunnel.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net"
@@ -16,48 +15,38 @@ type Tunnel struct {
 	RemoteHost string // 远程连接地址
 	RemotePort int    // 远程端口
 	Gateway    *Gateway
-	ctx        context.Context
-	cancel     context.CancelFunc
 	listener   net.Listener
 	err        error
 }
 
 func (r *Tunnel) Open() {
 	localAddr := fmt.Sprintf("%s:%d", r.LocalHost, r.LocalPort)
-	for {
-		select {
-		case <-r.ctx.Done():
-			_ = r.listener.Close()
-			log.Debugf("SSH 隧道 %v 关闭", localAddr)
-			return
-		default:
-			log.Debugf("等待客户端访问 %v", localAddr)
-			localConn, err := r.listener.Accept()
-			if err != nil {
-				log.Debugf("接受连接失败 %v", err.Error())
-				continue
-			}
 
-			log.Debugf("客户端 %v 连接至 %v", localConn.RemoteAddr().String(), localAddr)
-			remoteAddr := fmt.Sprintf("%s:%d", r.RemoteHost, r.RemotePort)
-			log.Debugf("连接远程主机 %v ...", remoteAddr)
-			remoteConn, err := r.Gateway.SshClient.Dial("tcp", remoteAddr)
-			if err != nil {
-				log.Debugf("连接远程主机 %v 失败", remoteAddr)
-				r.err = err
-				return
-			}
-
-			log.Debugf("连接远程主机 %v 成功", remoteAddr)
-			go copyConn(localConn, remoteConn)
-			go copyConn(remoteConn, localConn)
-			log.Debugf("转发数据 [%v]->[%v]", localAddr, remoteAddr)
-		}
+	log.Debugf("等待客户端访问 %v", localAddr)
+	localConn, err := r.listener.Accept()
+	if err != nil {
+		log.Debugf("接受连接失败 %v", err.Error())
+		return
 	}
+
+	log.Debugf("客户端 %v 连接至 %v", localConn.RemoteAddr().String(), localAddr)
+	remoteAddr := fmt.Sprintf("%s:%d", r.RemoteHost, r.RemotePort)
+	log.Debugf("连接远程主机 %v ...", remoteAddr)
+	remoteConn, err := r.Gateway.SshClient.Dial("tcp", remoteAddr)
+	if err != nil {
+		log.Debugf("连接远程主机 %v 失败", remoteAddr)
+		r.err = err
+		return
+	}
+
+	log.Debugf("连接远程主机 %v 成功", remoteAddr)
+	go copyConn(localConn, remoteConn)
+	go copyConn(remoteConn, localConn)
+	log.Debugf("转发数据 [%v]->[%v]", localAddr, remoteAddr)
 }
 
 func (r Tunnel) Close() {
-	r.cancel()
+	r.listener.Close()
 }
 
 func copyConn(writer, reader net.Conn) {


### PR DESCRIPTION
原先的case <-r.ctx.Done():  无法调用到，并且 一个gateway tunnel 只服务一个连接 ，所以不需要for 循环accept。
![image](https://user-images.githubusercontent.com/12092945/165049901-b46c99f2-e4f7-4639-bb3b-8a4c511f849e.png)
