### PR TITLE
fix: 监控时增加只读模式参数, 提升安全性

### DIFF
--- a/server/api/guacamole.go
+++ b/server/api/guacamole.go
@@ -224,6 +224,7 @@ func (api GuacamoleApi) GuacamoleMonitor(c echo.Context) error {
 	configuration.SetParameter("width", strconv.Itoa(s.Width))
 	configuration.SetParameter("height", strconv.Itoa(s.Height))
 	configuration.SetParameter("dpi", "96")
+	configuration.SetReadOnlyMode()
 
 	addr := config.GlobalCfg.Guacd.Hostname + ":" + strconv.Itoa(config.GlobalCfg.Guacd.Port)
 

--- a/server/common/guacamole/guacd.go
+++ b/server/common/guacamole/guacd.go
@@ -52,6 +52,7 @@ const (
 	SwapRedBlue = "swap-red-blue"
 	DestHost    = "dest-host"
 	DestPort    = "dest-port"
+	ReadOnly    = "read-only"
 
 	UsernameRegex     = "username-regex"
 	PasswordRegex     = "password-regex"
@@ -81,6 +82,10 @@ func NewConfiguration() (config *Configuration) {
 	config = &Configuration{}
 	config.Parameters = make(map[string]string)
 	return config
+}
+
+func (opt *Configuration) SetReadOnlyMode() {
+	opt.Parameters[ReadOnly] = "true"
 }
 
 func (opt *Configuration) SetParameter(name, value string) {


### PR DESCRIPTION
可以参考 https://guacamole.apache.org/doc/gug/configuring-guacamole.html read-only参数