### PR TITLE
监听localhost进行转发隧道

### DIFF
--- a/server/global/gateway/gateway.go
+++ b/server/global/gateway/gateway.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"next-terminal/server/common/term"
-	"os"
 	"sync"
 
 	"next-terminal/server/utils"
@@ -51,15 +50,10 @@ func (g *Gateway) OpenSshTunnel(id, ip string, port int) (exposedIP string, expo
 		return "", 0, err
 	}
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", 0, err
-	}
-
 	// debug
 	//hostname = "0.0.0.0"
 
-	localAddr := fmt.Sprintf("%s:%d", hostname, localPort)
+	localAddr := fmt.Sprintf("localhost:%d", localPort)
 	listener, err := net.Listen("tcp", localAddr)
 	if err != nil {
 		return "", 0, err
@@ -67,7 +61,7 @@ func (g *Gateway) OpenSshTunnel(id, ip string, port int) (exposedIP string, expo
 
 	tunnel := &Tunnel{
 		id:        id,
-		localHost: hostname,
+		localHost: "localhost",
 		//localHost:  "docker.for.mac.host.internal",
 		localPort:  localPort,
 		remoteHost: ip,


### PR DESCRIPTION
原先需要获取的主机名用于创建转发隧道，但如果host中没有记录自己的主机名，那么在进行连接的时候会去查询dns服务器，如果dns服务器查询失败导致连接失败提示:listen tcp: lookup 【hostname】 on 【dns服务器IP】:53: no such host
我选择直接监听localhost进行转发隧道来避免这个问题。