### PR TITLE
feat: ssh 直接登录资产，同时支持私钥认证

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,3 +23,4 @@ sshd:
   enable: true
   addr: 0.0.0.0:8089
   key: ~/.ssh/id_rsa
+  authorized-keys: ~/.ssh/authorized_keys

--- a/config.yml.example
+++ b/config.yml.example
@@ -22,3 +22,4 @@ sshd:
   enable: true
   addr: 0.0.0.0:2022
   key: ~/.ssh/id_rsa
+  authorized-keys: ~/.ssh/authorized_keys

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil/v3 v3.23.4
 	github.com/sirupsen/logrus v1.9.0
+	github.com/spf13/cast v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
@@ -58,7 +59,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/shoenig/go-m1cpu v0.1.5 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
-	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -64,9 +64,10 @@ type Guacd struct {
 }
 
 type Sshd struct {
-	Enable bool
-	Addr   string
-	Key    string
+	Enable         bool
+	Addr           string
+	Key            string
+	AuthorizedKeys string
 }
 
 func SetupConfig() (*Config, error) {
@@ -103,6 +104,7 @@ func SetupConfig() (*Config, error) {
 	pflag.Bool("sshd.enable", false, "true or false")
 	pflag.String("sshd.addr", "", "sshd server listen addr")
 	pflag.String("sshd.key", "~/.ssh/id_rsa", "sshd public key filepath")
+	pflag.String("sshd.authorized-keys", "/root/.ssh/authorized_keys", "sshd authorized keys filepath")
 
 	pflag.Parse()
 	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
@@ -156,9 +158,10 @@ func SetupConfig() (*Config, error) {
 			Drive:     guacdDrive,
 		},
 		Sshd: &Sshd{
-			Enable: viper.GetBool("sshd.enable"),
-			Addr:   viper.GetString("sshd.addr"),
-			Key:    sshdKey,
+			Enable:         viper.GetBool("sshd.enable"),
+			Addr:           viper.GetString("sshd.addr"),
+			Key:            sshdKey,
+			AuthorizedKeys: viper.GetString("sshd.authorized-keys"),
 		},
 	}
 

--- a/server/repository/asset.go
+++ b/server/repository/asset.go
@@ -231,6 +231,11 @@ func (r assetRepository) FindAttrById(c context.Context, assetId string) (o []mo
 	return o, err
 }
 
+func (r assetRepository) FindAssetByName(c context.Context, name string, protocol string) (o model.Asset, err error) {
+	err = r.GetDB(c).Where("name = ? and protocol = ?", name, protocol).First(&o).Error
+	return
+}
+
 func (r assetRepository) FindAssetAttrMapByAssetId(c context.Context, assetId string) (map[string]string, error) {
 	asset, err := r.FindById(c, assetId)
 	if err != nil {

--- a/server/service/worker.go
+++ b/server/service/worker.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"next-terminal/server/common/sets"
 	"next-terminal/server/model"
 	"next-terminal/server/repository"
@@ -25,6 +26,26 @@ func (s *workerService) FindMyAssetPaging(pageIndex, pageSize int, name, protoco
 	}
 
 	return items, total, nil
+}
+
+func (s *workerService) FindMyAssetByName(name, protocol, userId string) (o model.Asset, err error) {
+	assetIdList, err := s.getAssetIdListByUserId(userId)
+	if err != nil {
+		return model.Asset{}, err
+	}
+	item, err := repository.AssetRepository.FindAssetByName(context.Background(), name, protocol)
+	if err != nil {
+		return model.Asset{}, err
+	}
+
+	if len(assetIdList) > 0 {
+		for _, id := range assetIdList {
+			if item.ID == id {
+				return item, nil
+			}
+		}
+	}
+	return model.Asset{}, fmt.Errorf("资产不存在")
 }
 
 func (s *workerService) FindMyAsset(name, protocol, tags string, userId string, order, field string) (o []model.AssetForPage, err error) {

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@ant-design/charts": "^1.4.2",
     "@ant-design/icons": "^4.7.0",
+    "@ant-design/plots": "^2.1.11",
     "@ant-design/pro-components": "1.1.21",
     "@turf/bbox": "^6.5.0",
     "antd": "4.23.5",


### PR DESCRIPTION
### 功能一：
读取 ~/.ssh/authorized_keys 中的内容，格式：
```
ssh-rsa xxxxx username
ssh-ed25519 xxxxx admin
ssh-ed25519 xxxxxxxx admin
```
comment是用户名，如果私钥匹配上就不再totp验证

### 功能二：
通过ssh指令直接选中资产，但只支持公钥认证时使用，格式
```
ssh username@assetname@next-termip -p port
```
例如
```
ssh admin@linux-01@192.168.1.1 -p 10000
```
